### PR TITLE
Shippable Continuos Integration

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,35 @@
+language: python
+
+python:
+  - 2.7
+
+env:
+  global:
+    - GAE_DIR=/tmp/gae
+    - EMAIL=shippable@gmail.com
+    - secure: lffPR8giDdKinq1LfjTabgM8Lufb3sdweFWJcoU8o/KIvwTg9NOxEw3oG5pw4+pI0c3q/k0JkBv7QgDGkoiRHwZkebWYNcHwyo2NFaa/cpwpNjv3pMZsXpMiw+duSvfjA/XmFAynmW8/ft2YaAzpB1Mbn5p2k7ID2qCMv/YmFgIu605VK/WUnYPEdxMD2vkifVSNAIH42GOR+2ht4nKj85Wsu9OGgMBJ5XAqVcQoWX+Ui9yZvtaf3WKzowg+MC4PQ0qGLH/l6WHkY8bBCduMz65JjZIss2s972L4P8Hwpk+gDdVtRE82hKH7GuEYdNKhKjbthZmn5AF4thI72N5TjQ==
+
+before_install:
+  - >
+    test -e $GAE_DIR || 
+    (mkdir -p $GAE_DIR && 
+     wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.23.zip -q -O /tmp/gae.zip &&
+     unzip /tmp/gae.zip -d $GAE_DIR)
+  - export PYTHONPATH="$PYTHONPATH:$GAE_DIR/google_appengine"
+  - export GAE_SDK=$GAE_DIR/google_appengine
+  - export PATH=/bin:/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:$GAE_DIR:$PATH
+
+
+install:
+  - sudo pip install -r venv/shippable_requirements.txt
+
+script:
+  - nosetests
+
+notifications:
+     email:
+         recipients:
+            - felipevolpone@gmail.com
+            - renzo.n@gmail.com
+         on_success: change
+         on_failure: always

--- a/venv/shippable_requirements.txt
+++ b/venv/shippable_requirements.txt
@@ -1,0 +1,6 @@
+mock==1.0.1
+pytz==2014.4
+Babel==1.3
+webapp2
+nose
+webob


### PR DESCRIPTION
I added some files to connect the project with shippable continuous integration. Obviously that @renzon  should enable it on his dashboard on shippable.com, but all configuration it's already done.

Unfortunately, I created another file to keep the dependencies that shippable needs to run the tests. I know that is not a good pattern, but I guess it is good enough to the current situation.

Any problem, please tell me.
